### PR TITLE
Fixed name data going missing (#5).

### DIFF
--- a/src/main/java/com/livinglemming/Events/RightClickEventListener.java
+++ b/src/main/java/com/livinglemming/Events/RightClickEventListener.java
@@ -61,12 +61,15 @@ public class RightClickEventListener {
                     }
                     LoreComponent loreData = new LoreComponent(lore);
 
-                    ComponentChanges changes = ComponentChanges.builder()
+                    ComponentChanges.Builder changes = ComponentChanges.builder()
                             .add(DataComponentTypes.ENTITY_DATA, entityData)
-                            .add(DataComponentTypes.LORE, loreData)
-                            .build();
+                            .add(DataComponentTypes.LORE, loreData);
 
-                    spawnEggStack.applyChanges(changes);
+                    if(villager.hasCustomName()) {
+                        changes.add(DataComponentTypes.CUSTOM_NAME, villager.getCustomName());
+                    }
+
+                    spawnEggStack.applyChanges(changes.build());
                     if (player.getInventory().getEmptySlot() != -1) {
                         player.giveItemStack(spawnEggStack);
                     } else {


### PR DESCRIPTION
Maybe adding a config to prevent Villager Renaming in an Anvil would be a good to have.

Not creating a release for this yet, but **build artifacts will be available for those who want to have this version early, however be aware that currently it's possible to rename villagers using an anvil in this way**.

Here's a video of the fixed issue:

https://github.com/user-attachments/assets/c30ddbc4-c140-4818-8293-ddda39fd40ed

