### PR TITLE
Villagers lose sleeping_pos NBT when picked up (close #23)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.5+build.1
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.1.5-1.21.5
+mod_version=1.1.6-1.21.5
 maven_group=com.livinglemming
 archives_base_name=villager-pickup
 

--- a/src/main/java/com/livinglemming/events/RightClickEventListener.java
+++ b/src/main/java/com/livinglemming/events/RightClickEventListener.java
@@ -36,6 +36,8 @@ public class RightClickEventListener {
                 NbtCompound nbt = new NbtCompound();
                 villager.writeCustomDataToNbt(nbt);
 
+                if(nbt.contains("sleeping_pos")) nbt.remove("sleeping_pos");
+
                 Item spawnEgg = SpawnEggItem.forEntity(villager.getType());
                 if (spawnEgg != null) {
                     ItemStack spawnEggStack = new ItemStack(spawnEgg);


### PR DESCRIPTION
This pull request modifies the `registerRightClickEvent` method in `RightClickEventListener.java` to ensure that a specific NBT tag (`sleeping_pos`) is removed if it exists. This change improves the handling of villager data during right-click events.

Key change:

* [`src/main/java/com/livinglemming/events/RightClickEventListener.java`](diffhunk://#diff-aeef23f365c311f613f9a1419685b44c3c2e705c24a2171afbd962083d2a6f26R39-R40): Added logic to check for and remove the `sleeping_pos` NBT tag from villager data to prevent unintended behavior related to sleeping positions.